### PR TITLE
TCP/IP ports/addresses in flow metadata

### DIFF
--- a/httpx/har.go
+++ b/httpx/har.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"time"
 
@@ -146,7 +145,7 @@ func (h *HAR) addRequest(ctx session.Context, hh *har, req *Request) {
 			Wait:    1,
 			Receive: 1,
 		},
-		ServerIPAddress: lookupServerIP(req),
+		ServerIPAddress: req.ServerAddr,
 		Connection:      req.GetConnectionID(),
 	}
 
@@ -210,26 +209,6 @@ func extractPostData(req *Request) harPOST {
 	}
 
 	return post
-}
-
-// lookupServerIP will look up the server IP address of an httpx Request based on the Host field. Port notations
-// are handled properly. If the host resolves to multiple IPs, only the first is returned. An error in any portion
-// of the lookup results in the empty string being returned.
-func lookupServerIP(req *Request) string {
-	var adds []net.IP
-
-	host, _, err := net.SplitHostPort(req.Host)
-	if err == nil {
-		adds, err = net.LookupIP(host)
-	} else {
-		adds, err = net.LookupIP(req.Host)
-	}
-
-	if err != nil {
-		return ""
-	}
-
-	return adds[0].String()
 }
 
 // mapToHarNVP ranges over a map[string][]string and returns a slice of harNVP.

--- a/httpx/har_test.go
+++ b/httpx/har_test.go
@@ -43,7 +43,8 @@ func TestHAR(t *testing.T) {
 					Header: http.Header{
 						"a": []string{"a"},
 					},
-					URL: newURL("http://example.org"),
+					URL:        newURL("http://example.org"),
+					ServerAddr: "10.10.10.1",
 				},
 				&Response{
 					ConnectionID: "111",
@@ -78,7 +79,7 @@ func TestHAR(t *testing.T) {
 								Wait:    1,
 								Receive: 1,
 							},
-							ServerIPAddress: "",
+							ServerIPAddress: "10.10.10.1",
 							Connection:      "111",
 						},
 					},
@@ -108,6 +109,7 @@ func TestHAR(t *testing.T) {
 					Body:          "",
 					ContentLength: 1,
 					RequestURI:    "/111.html",
+					ServerAddr:    "10.10.10.1",
 				},
 				&Response{
 					ConnectionID: "111",
@@ -134,6 +136,7 @@ func TestHAR(t *testing.T) {
 					Body:          "",
 					ContentLength: 15,
 					RequestURI:    "/111.html",
+					ServerAddr:    "10.10.10.2",
 				},
 				&Response{
 					ConnectionID: "112",
@@ -157,6 +160,7 @@ func TestHAR(t *testing.T) {
 					Body:          "{\"baz\":\"qux\",\"foo\":\"bar\"}",
 					ContentLength: 25,
 					RequestURI:    "/111.html",
+					ServerAddr:    "10.10.10.3",
 				},
 				&Response{
 					ConnectionID: "113",
@@ -193,7 +197,7 @@ func TestHAR(t *testing.T) {
 								Wait:    1,
 								Receive: 1,
 							},
-							ServerIPAddress: "",
+							ServerIPAddress: "10.10.10.1",
 							Connection:      "111",
 						},
 						{ // POST url-encoded
@@ -224,7 +228,7 @@ func TestHAR(t *testing.T) {
 								Wait:    1,
 								Receive: 1,
 							},
-							ServerIPAddress: "",
+							ServerIPAddress: "10.10.10.2",
 							Connection:      "112",
 						},
 						{ // POST JSON (not url-encoded)
@@ -254,7 +258,7 @@ func TestHAR(t *testing.T) {
 								Wait:    1,
 								Receive: 1,
 							},
-							ServerIPAddress: "",
+							ServerIPAddress: "10.10.10.3",
 							Connection:      "113",
 						},
 					},
@@ -383,42 +387,42 @@ func TestExtractPostData(t *testing.T) {
 	}
 }
 
-func TestLookupServerIP(t *testing.T) {
-	testCases := []struct {
-		desc  string
-		req   *Request
-		refIP string
-	}{
-		{
-			desc: "default",
-			req: &Request{
-				Host: "example.com",
-			},
-			refIP: "93.184.216.34",
-		},
-		{
-			desc: "with port",
-			req: &Request{
-				Host: "example.com:80",
-			},
-			refIP: "93.184.216.34",
-		},
-		{
-			desc: "does not resolve",
-			req: &Request{
-				Host: "example.invalid.",
-			},
-			refIP: "",
-		},
-	}
-	for _, c := range testCases {
-		t.Run(c.desc, func(t *testing.T) {
-			IPstr := lookupServerIP(c.req)
-
-			assert.Equal(t, IPstr, c.refIP)
-		})
-	}
-}
+// func TestLookupServerIP(t *testing.T) {
+// 	testCases := []struct {
+// 		desc  string
+// 		req   *Request
+// 		refIP string
+// 	}{
+// 		{
+// 			desc: "default",
+// 			req: &Request{
+// 				Host: "example.com",
+// 			},
+// 			refIP: "93.184.216.34",
+// 		},
+// 		{
+// 			desc: "with port",
+// 			req: &Request{
+// 				Host: "example.com:80",
+// 			},
+// 			refIP: "93.184.216.34",
+// 		},
+// 		{
+// 			desc: "does not resolve",
+// 			req: &Request{
+// 				Host: "example.invalid.",
+// 			},
+// 			refIP: "",
+// 		},
+// 	}
+// 	for _, c := range testCases {
+// 		t.Run(c.desc, func(t *testing.T) {
+// 			IPstr := lookupServerIP(c.req)
+//
+// 			assert.Equal(t, IPstr, c.refIP)
+// 		})
+// 	}
+// }
 
 func TestMapToHarNVP(t *testing.T) {
 	cases := []struct {

--- a/httpx/har_test.go
+++ b/httpx/har_test.go
@@ -387,42 +387,6 @@ func TestExtractPostData(t *testing.T) {
 	}
 }
 
-// func TestLookupServerIP(t *testing.T) {
-// 	testCases := []struct {
-// 		desc  string
-// 		req   *Request
-// 		refIP string
-// 	}{
-// 		{
-// 			desc: "default",
-// 			req: &Request{
-// 				Host: "example.com",
-// 			},
-// 			refIP: "93.184.216.34",
-// 		},
-// 		{
-// 			desc: "with port",
-// 			req: &Request{
-// 				Host: "example.com:80",
-// 			},
-// 			refIP: "93.184.216.34",
-// 		},
-// 		{
-// 			desc: "does not resolve",
-// 			req: &Request{
-// 				Host: "example.invalid.",
-// 			},
-// 			refIP: "",
-// 		},
-// 	}
-// 	for _, c := range testCases {
-// 		t.Run(c.desc, func(t *testing.T) {
-// 			IPstr := lookupServerIP(c.req)
-//
-// 			assert.Equal(t, IPstr, c.refIP)
-// 		})
-// 	}
-// }
 
 func TestMapToHarNVP(t *testing.T) {
 	cases := []struct {

--- a/httpx/input_format.go
+++ b/httpx/input_format.go
@@ -70,7 +70,7 @@ func (i *inputFormat) Init(ctx session.Context, m middleware.Middleware, streams
 						eID := ksuid.New().String()
 						exchangeIDs <- eID
 
-						req, err := NewRequest(buf, sourceID, eID)
+						req, err := NewRequest(buf, sourceID, eID, r.Meta())
 						if isEOF(err) {
 							return
 						}
@@ -86,7 +86,7 @@ func (i *inputFormat) Init(ctx session.Context, m middleware.Middleware, streams
 					for {
 						eID := <-exchangeIDs
 
-						res, err := NewResponse(buf, sourceID, eID)
+						res, err := NewResponse(buf, sourceID, eID, r.Meta())
 						if isEOF(err) {
 							return
 						}

--- a/httpx/response_test.go
+++ b/httpx/response_test.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/rename-this/vhs/flow"
+	"github.com/rename-this/vhs/tcp"
 )
 
 func TestNewResponset(t *testing.T) {
@@ -17,16 +20,19 @@ func TestNewResponset(t *testing.T) {
 		r           *Response
 		cID         string
 		eID         string
+		meta        *flow.Meta
 		errContains string
 	}{
 		{
 			desc:        "EOF",
 			b:           bufio.NewReader(strings.NewReader("")),
+			meta:        nil,
 			errContains: "EOF",
 		},
 		{
 			desc:        "malformed",
 			b:           bufio.NewReader(strings.NewReader("AICHTEETEEPEE/1.1 200 OK")),
+			meta:        nil,
 			errContains: "malformed HTTP version",
 		},
 		{
@@ -34,6 +40,12 @@ func TestNewResponset(t *testing.T) {
 			cID:  "111",
 			eID:  "111",
 			b:    bufio.NewReader(strings.NewReader("HTTP/1.1 204 No Content\r\n\r\n")),
+			meta: flow.NewMeta("source", map[string]interface{}{
+				tcp.MetaDstAddr: "10.10.10.1",
+				tcp.MetaDstPort: "2346",
+				tcp.MetaSrcAddr: "10.10.10.2",
+				tcp.MetaSrcPort: "80",
+			}),
 			r: &Response{
 				ConnectionID:  "111",
 				ExchangeID:    "111",
@@ -46,6 +58,10 @@ func TestNewResponset(t *testing.T) {
 				Cookies:       []*http.Cookie{},
 				Body:          "",
 				ContentLength: 0,
+				ClientAddr:    "10.10.10.1",
+				ClientPort:    "2346",
+				ServerAddr:    "10.10.10.2",
+				ServerPort:    "80",
 			},
 		},
 		{
@@ -53,6 +69,12 @@ func TestNewResponset(t *testing.T) {
 			cID:  "111",
 			eID:  "111",
 			b:    bufio.NewReader(strings.NewReader("HTTP/1.1 204 No Content\r\nLocation: /111.html\r\nSet-Cookie: grault=foo\r\n\r\n")),
+			meta: flow.NewMeta("source", map[string]interface{}{
+				tcp.MetaDstAddr: "10.10.10.1",
+				tcp.MetaDstPort: "2346",
+				tcp.MetaSrcAddr: "10.10.10.2",
+				tcp.MetaSrcPort: "80",
+			}),
 			r: &Response{
 				ConnectionID: "111",
 				ExchangeID:   "111",
@@ -69,12 +91,16 @@ func TestNewResponset(t *testing.T) {
 				Body:          "",
 				ContentLength: 0,
 				Location:      "/111.html",
+				ClientAddr:    "10.10.10.1",
+				ClientPort:    "2346",
+				ServerAddr:    "10.10.10.2",
+				ServerPort:    "80",
 			},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			r, err := NewResponse(c.b, c.cID, c.eID)
+			r, err := NewResponse(c.b, c.cID, c.eID, c.meta)
 			if c.errContains != "" {
 				assert.ErrorContains(t, err, c.errContains)
 			} else {

--- a/internal/ioutilx/ioutilx.go
+++ b/internal/ioutilx/ioutilx.go
@@ -14,6 +14,6 @@ type nopWriteCloser struct {
 	io.Writer
 }
 
-func (nopWriteCloser) Close() error { 
-	return nil 
+func (nopWriteCloser) Close() error {
+	return nil
 }

--- a/internal/prunemap/prunemap.go
+++ b/internal/prunemap/prunemap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 	"time"
-
 )
 
 type item struct {

--- a/tcp/stream_factory.go
+++ b/tcp/stream_factory.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/tcpassembly"
 	"github.com/google/gopacket/tcpassembly/tcpreader"
+
 	"github.com/rename-this/vhs/flow"
 	"github.com/rename-this/vhs/session"
 )
@@ -24,6 +25,10 @@ const (
 const (
 	// MetaDirection is a key for a flow.Meta to retrieve a direction.
 	MetaDirection = "tcp.direction"
+	MetaSrcAddr   = "ip.srcaddr"
+	MetaDstAddr   = "ip.dstaddr"
+	MetaSrcPort   = "tcp.srcport"
+	MetaDstPort   = "tcp.dstport"
 )
 
 func newStreamFactory(ctx session.Context, out chan<- flow.InputReader) *streamFactory {
@@ -110,6 +115,10 @@ func (f *streamFactory) New(net, transport gopacket.Flow) tcpassembly.Stream {
 		s:   s,
 		meta: flow.NewMeta(s.conn.id, map[string]interface{}{
 			MetaDirection: d,
+			MetaSrcAddr:   net.Src().String(),
+			MetaSrcPort:   transport.Src().String(),
+			MetaDstAddr:   net.Dst().String(),
+			MetaDstPort:   transport.Dst().String(),
 		}),
 	}
 


### PR DESCRIPTION
This PR adds IP address information and TCP port information to the flow meta data for flows originating from the TCP source. I also added support to `httpx/request` and `httpx/response` which now have the following fields:

`ClientAddr` for client IP address
`ClientPort` for client TCP port
`ServerAddr` for server IP address
`ServerPort` for server TCP port

Finally, I updated the HAR format to grab server IP addresses from this metadata instead of doing DNS lookups to populate the field `serverIPAddress`. This field is optional according to the HAR specification, so if the HAR format is used with a data source that doesn't provide IP data the `serverIPAddress` field will be left blank. 