### PR TITLE
Duration and context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--network host \
-		-it vhs:test \
+		-i vhs:test \
 		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
 
 .PHONY: dev

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--network host \
-		-i vhs:test \
+		-it vhs:test \
 		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
 
 .PHONY: dev

--- a/capture/listener_test.go
+++ b/capture/listener_test.go
@@ -36,7 +36,7 @@ func TestNewHandle(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
+			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
 			l := NewListener(&Capture{})
 			_, err := l.(*listener).newHandle(ctx, c.i, c.activate)
 			if c.errContains == "" {
@@ -107,7 +107,7 @@ func TestReadPackets(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			packets := c.listener.Packets()
 
-			ctx, _, _ := session.NewContexts(&session.Config{DebugPackets: true}, &session.FlowConfig{}, nil)
+			ctx := session.NewContexts(&session.Config{DebugPackets: true}, &session.FlowConfig{}, nil)
 
 			go c.listener.(*listener).readPackets(ctx, c.source, c.decoder)
 			for _, d := range c.source.data {

--- a/cmd/vhs/main.go
+++ b/cmd/vhs/main.go
@@ -54,7 +54,7 @@ func newRootCmd() *cobra.Command {
 	)
 
 	cmd.PersistentFlags().DurationVar(&flowCfg.SourceDuration, "source-duration", math.MaxInt64, "The length of the source is left open. Leave this empty to read to EOF.")
-	cmd.PersistentFlags().DurationVar(&flowCfg.DrainDuration, "drain-duration", 10*time.Second, "A grace period to allow for data to drain to sink(s).")
+	cmd.PersistentFlags().DurationVar(&flowCfg.InputDrainDuration, "input-drain-duration", 500*time.Millisecond, "A grace period to allow for inputs to drain.")
 	cmd.PersistentFlags().StringVar(&flowCfg.Addr, "address", capture.DefaultAddr, "Address VHS will use to capture traffic.")
 	cmd.PersistentFlags().BoolVar(&flowCfg.CaptureResponse, "capture-response", false, "Capture the responses.")
 	cmd.PersistentFlags().StringVar(&flowCfg.Middleware, "middleware", "", "A path to an executable that VHS will use as middleware.")

--- a/cmd/vhs/main.go
+++ b/cmd/vhs/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -52,9 +53,8 @@ func newRootCmd() *cobra.Command {
 		outputLines []string
 	)
 
-	cmd.PersistentFlags().DurationVar(&flowCfg.FlowDuration, "flow-duration", 10*time.Second, "The length of the running command.")
-	cmd.PersistentFlags().DurationVar(&flowCfg.InputDrainDuration, "input-drain-duration", 2*time.Second, "A grace period to allow for a inputs to drain.")
-	cmd.PersistentFlags().DurationVar(&flowCfg.ShutdownDuration, "shutdown-duration", 2*time.Second, "A grace period to allow for a clean shutdown.")
+	cmd.PersistentFlags().DurationVar(&flowCfg.SourceDuration, "source-duration", math.MaxInt64, "The length of the source is left open. Leave this empty to read to EOF.")
+	cmd.PersistentFlags().DurationVar(&flowCfg.DrainDuration, "drain-duration", 10*time.Second, "A grace period to allow for data to drain to sink(s).")
 	cmd.PersistentFlags().StringVar(&flowCfg.Addr, "address", capture.DefaultAddr, "Address VHS will use to capture traffic.")
 	cmd.PersistentFlags().BoolVar(&flowCfg.CaptureResponse, "capture-response", false, "Capture the responses.")
 	cmd.PersistentFlags().StringVar(&flowCfg.Middleware, "middleware", "", "A path to an executable that VHS will use as middleware.")
@@ -97,8 +97,8 @@ func newRootCmd() *cobra.Command {
 
 func root(cfg *session.Config, flowCfg *session.FlowConfig, inputLine string, outputLines []string, parser *flow.Parser, logWriter io.Writer) error {
 	var (
-		errs                     = make(chan error, errBufSize)
-		ctx, inputCtx, outputCtx = session.NewContextsForWriter(cfg, flowCfg, errs, logWriter)
+		errs = make(chan error, errBufSize)
+		ctx  = session.NewContextsForWriter(cfg, flowCfg, errs, logWriter)
 	)
 
 	go func() {
@@ -166,12 +166,11 @@ func root(cfg *session.Config, flowCfg *session.FlowConfig, inputLine string, ou
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		ctx.Logger.Debug().Msgf("shutdown initiated, exiting in %s",
-			ctx.FlowConfig.InputDrainDuration+ctx.FlowConfig.ShutdownDuration)
+		ctx.Logger.Debug().Msg("shutdown requested")
 		ctx.Cancel()
 	}()
 
-	go f.Run(ctx, inputCtx, outputCtx, m)
+	go f.Run(ctx, m)
 
 	<-ctx.StdContext.Done()
 

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -28,8 +28,8 @@ func TestNewSource(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			var (
-				errs      = make(chan error, 1)
-				ctx, _, _ = session.NewContexts(&session.Config{}, &session.FlowConfig{InputFile: c.file}, errs)
+				errs = make(chan error, 1)
+				ctx  = session.NewContexts(&session.Config{}, &session.FlowConfig{InputFile: c.file}, errs)
 			)
 
 			s, err := NewSource(ctx)

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -25,7 +25,7 @@ func (f *Flow) Run(ctx session.Context, m middleware.Middleware) {
 	defer func() {
 		ctx.Cancel()
 
-		f.Outputs.Close(ctx)
+		f.Outputs.Drain(ctx)
 
 		ctx.Logger.Debug().Msg("complete")
 	}()

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -1,8 +1,6 @@
 package flow
 
 import (
-	"time"
-
 	"github.com/rename-this/vhs/middleware"
 	"github.com/rename-this/vhs/session"
 )
@@ -27,9 +25,9 @@ func (f *Flow) Run(ctx session.Context, m middleware.Middleware) {
 	defer func() {
 		ctx.Cancel()
 
-		ctx.Logger.Debug().Dur("dur", ctx.FlowConfig.DrainDuration).Msg("draining")
-		time.Sleep(ctx.FlowConfig.DrainDuration)
-		ctx.Logger.Debug().Msg("flow complete")
+		f.Outputs.Close(ctx)
+
+		ctx.Logger.Debug().Msg("complete")
 	}()
 
 	for {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -15,9 +15,9 @@ import (
 func TestFlow(t *testing.T) {
 	cfg := &session.Config{Debug: true}
 	flowCfg := &session.FlowConfig{
-		SourceDuration: 500 * time.Millisecond,
-		DrainDuration:  500 * time.Millisecond,
+		InputDrainDuration: 50 * time.Millisecond,
 	}
+
 	errs := make(chan error, 1)
 	ctx := session.NewContexts(cfg, flowCfg, errs)
 
@@ -34,14 +34,14 @@ func TestFlow(t *testing.T) {
 		}
 		i = NewInput(s, mis, ifmt)
 
-		ofmt1 = &testSinkInt{}
-		o1    = NewOutput(newTestOutputFormatNoErr(ctx), nil, ofmt1)
+		sink1 = &testSinkInt{}
+		o1    = NewOutput(newTestOutputFormatNoErr(ctx), nil, sink1)
 
 		mos = OutputModifiers{
 			&TestDoubleOutputModifier{},
 		}
-		ofmt2 = &testSinkInt{}
-		o2    = NewOutput(newTestOutputFormatNoErr(ctx), mos, ofmt2)
+		sink2 = &testSinkInt{}
+		o2    = NewOutput(newTestOutputFormatNoErr(ctx), mos, sink2)
 
 		oo = Outputs{o1, o2}
 
@@ -50,15 +50,11 @@ func TestFlow(t *testing.T) {
 
 	f.Run(ctx, nil)
 
-	ctx.Cancel()
-
-	time.Sleep(500 * time.Millisecond)
-
 	assert.Equal(t, 0, len(errs))
 
-	sort.Ints(ofmt1.data)
-	sort.Ints(ofmt2.data)
+	sort.Ints(sink1.data)
+	sort.Ints(sink2.data)
 
-	assert.DeepEqual(t, ofmt1.data, []int{1, 1, 2, 2, 3, 3})
-	assert.DeepEqual(t, ofmt2.data, []int{11, 11, 22, 22, 33, 33})
+	assert.DeepEqual(t, sink1.data, []int{1, 1, 2, 2, 3, 3})
+	assert.DeepEqual(t, sink2.data, []int{11, 11, 22, 22, 33, 33})
 }

--- a/flow/input.go
+++ b/flow/input.go
@@ -2,7 +2,9 @@ package flow
 
 import (
 	"fmt"
+	"sync"
 
+	"github.com/rename-this/vhs/internal/observe"
 	"github.com/rename-this/vhs/middleware"
 	"github.com/rename-this/vhs/session"
 )
@@ -13,6 +15,8 @@ type Input struct {
 	Source    Source
 	Modifiers InputModifiers
 	Format    InputFormat
+
+	done chan struct{}
 }
 
 // NewInput creates a new input.
@@ -21,7 +25,13 @@ func NewInput(s Source, mis InputModifiers, f InputFormat) *Input {
 		Source:    s,
 		Modifiers: mis,
 		Format:    f,
+		done:      make(chan struct{}),
 	}
+}
+
+// Done returns a channel indicating that this input is done.
+func (i *Input) Done() <-chan struct{} {
+	return i.done
 }
 
 // Init starts the input.
@@ -40,9 +50,33 @@ func (i *Input) Init(ctx session.Context, m middleware.Middleware) {
 	go i.Format.Init(ctx, m, streams)
 	go i.Source.Init(ctx)
 
+	var wg sync.WaitGroup
+
 	for {
 		select {
-		case rs := <-i.Source.Streams():
+		case rs, more := <-i.Source.Streams():
+			if !more {
+				ctx.Logger.Debug().Msg("no more source streams")
+				wg.Wait()
+				ctx.Logger.Debug().Msg("all source streams EOF")
+				i.done <- struct{}{}
+				return
+			}
+
+			wg.Add(1)
+
+			rc := observe.NewReadCloser(rs)
+			go func() {
+				<-rc.EOF()
+				ctx.Logger.Debug().Msg("source stream EOF")
+				wg.Done()
+			}()
+
+			rs = &wrappedStream{
+				rc:   rc,
+				meta: rs.Meta(),
+			}
+
 			r, err := i.Modifiers.Wrap(rs)
 			if err != nil {
 				ctx.Errors <- fmt.Errorf("failed to wrap source stream: %w", err)
@@ -54,4 +88,21 @@ func (i *Input) Init(ctx session.Context, m middleware.Middleware) {
 			return
 		}
 	}
+}
+
+type wrappedStream struct {
+	rc   observe.ReadCloser
+	meta *Meta
+}
+
+func (s *wrappedStream) Read(p []byte) (int, error) {
+	return s.rc.Read(p)
+}
+
+func (s *wrappedStream) Close() error {
+	return s.rc.Close()
+}
+
+func (s *wrappedStream) Meta() *Meta {
+	return s.meta
 }

--- a/flow/input.go
+++ b/flow/input.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/rename-this/vhs/internal/observe"
 	"github.com/rename-this/vhs/middleware"
@@ -59,6 +60,7 @@ func (i *Input) Init(ctx session.Context, m middleware.Middleware) {
 				ctx.Logger.Debug().Msg("no more source streams")
 				wg.Wait()
 				ctx.Logger.Debug().Msg("all source streams EOF")
+				time.Sleep(ctx.FlowConfig.InputDrainDuration)
 				i.done <- struct{}{}
 				return
 			}

--- a/flow/input_test.go
+++ b/flow/input_test.go
@@ -64,7 +64,7 @@ func TestInput(t *testing.T) {
 			// hack: Make this big enough to handle any errors we
 			// might end up with.
 			errs := make(chan error, 10)
-			ctx, _, _ := session.NewContexts(nil, nil, errs)
+			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{DrainDuration: 50 * time.Millisecond}, errs)
 
 			var (
 				s = &testSource{

--- a/flow/input_test.go
+++ b/flow/input_test.go
@@ -64,7 +64,7 @@ func TestInput(t *testing.T) {
 			// hack: Make this big enough to handle any errors we
 			// might end up with.
 			errs := make(chan error, 10)
-			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{DrainDuration: 50 * time.Millisecond}, errs)
+			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, errs)
 
 			var (
 				s = &testSource{

--- a/flow/modifiers_test.go
+++ b/flow/modifiers_test.go
@@ -66,10 +66,6 @@ func (m *TestDoubleInputModifier) Wrap(r InputReader) (InputReader, error) {
 	}), nil
 }
 
-type testDoubleInputModifier struct {
-	r InputReader
-}
-
 type TestErrInputModifier struct {
 	err error
 }
@@ -91,6 +87,10 @@ type errWriteCloser struct {
 }
 
 func (n *errWriteCloser) Close() error { return n.err }
+
+type testDoubleInputModifier struct {
+	r InputReader
+}
 
 func (i *testDoubleInputModifier) Read(p []byte) (int, error) {
 	b, err := ioutil.ReadAll(i.r)

--- a/flow/output.go
+++ b/flow/output.go
@@ -78,7 +78,7 @@ func (oo Outputs) Init(ctx session.Context) {
 	}
 }
 
-// Drain closes all outputs.
+// Drain drains all outputs.
 func (oo Outputs) Drain(ctx session.Context) {
 	ctx.Logger = ctx.Logger.With().
 		Str(session.LoggerKeyComponent, "outputs").

--- a/flow/output.go
+++ b/flow/output.go
@@ -78,13 +78,13 @@ func (oo Outputs) Init(ctx session.Context) {
 	}
 }
 
-// Close closes all outputs.
-func (oo Outputs) Close(ctx session.Context) {
+// Drain closes all outputs.
+func (oo Outputs) Drain(ctx session.Context) {
 	ctx.Logger = ctx.Logger.With().
 		Str(session.LoggerKeyComponent, "outputs").
 		Logger()
 
-	ctx.Logger.Debug().Msg("closing")
+	ctx.Logger.Debug().Msg("draining")
 
 	var (
 		wg  sync.WaitGroup

--- a/flow/output_test.go
+++ b/flow/output_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestOutput(t *testing.T) {
-	ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
-	ctxBuffered, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{BufferOutput: true}, nil)
+	ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
+	ctxBuffered := session.NewContexts(&session.Config{}, &session.FlowConfig{BufferOutput: true}, nil)
 
 	cases := []struct {
 		desc        string
@@ -80,12 +80,16 @@ func TestOutput(t *testing.T) {
 			// hack: Make this big enough to handle any errors we
 			// might end up with.
 			errs := make(chan error, 10)
-			ctx, _, _ := session.NewContexts(nil, nil, errs)
+			ctx := session.NewContexts(nil, nil, errs)
 
-			go c.oo.Init(ctx)
+			for _, o := range c.oo {
+				go o.Init(ctx)
+			}
 
 			for _, d := range c.data {
-				c.oo.Write(d)
+				for _, o := range c.oo {
+					o.Format.In() <- d
+				}
 			}
 
 			time.Sleep(500 * time.Millisecond)

--- a/flow/parser.go
+++ b/flow/parser.go
@@ -47,7 +47,7 @@ func (p *Parser) Parse(ctx session.Context, inputLine string, outputLines []stri
 		return nil, fmt.Errorf("failed to parse input: %v", err)
 	}
 
-	var outputs Outputs
+	var outputs []*Output
 	for _, outputLine := range outputLines {
 		o, err := p.parseOutput(ctx, outputLine)
 		if err != nil {

--- a/flow/parser_test.go
+++ b/flow/parser_test.go
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 	}
 	for _, c := range cases {
 		parser := newTestParser()
-		ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
+		ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
 		t.Run(c.desc, func(t *testing.T) {
 			i, err := parser.Parse(ctx, c.inputLine, c.outputLines)
 			if c.errContains == "" {
@@ -90,7 +90,6 @@ func TestParse(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestParseInput(t *testing.T) {
@@ -189,7 +188,7 @@ func TestParseOutput(t *testing.T) {
 	}
 	for _, c := range cases {
 		parser := newTestParser()
-		ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
+		ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
 		t.Run(c.desc, func(t *testing.T) {
 			i, err := parser.parseOutput(ctx, c.line)
 			if c.errContains == "" {

--- a/flow/source_test.go
+++ b/flow/source_test.go
@@ -23,4 +23,5 @@ func (s *testSource) Init(ctx session.Context) {
 	for _, d := range s.data {
 		s.streams <- d
 	}
+	close(s.streams)
 }

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -66,6 +66,8 @@ func (s *gcsSource) Streams() <-chan flow.InputReader {
 }
 
 func (s *gcsSource) Init(ctx session.Context) {
+	defer close(s.streams)
+
 	ctx.Logger = ctx.Logger.With().
 		Str(session.LoggerKeyComponent, "gcs_source").
 		Logger()

--- a/gcs/gcs_test.go
+++ b/gcs/gcs_test.go
@@ -55,7 +55,7 @@ func TestNewSink(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			err := func() error {
-				ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{
+				ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{
 					GCSBucketName: c.bucketName,
 				}, nil)
 				ctx.SessionID = c.sessionID
@@ -162,7 +162,7 @@ func TestNewSource(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			errs := make(chan error, 10)
-			ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{
+			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{
 				GCSBucketName: c.bucketName,
 				GCSObjectName: c.objectName,
 			}, errs)
@@ -190,7 +190,7 @@ func TestNewSource(t *testing.T) {
 }
 
 func TestNewSinkFail(t *testing.T) {
-	ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
+	ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{}, nil)
 	_, err := NewSink(ctx)
 	assert.Assert(t, err != nil)
 }

--- a/httpx/correlator_test.go
+++ b/httpx/correlator_test.go
@@ -31,7 +31,7 @@ func TestCorrelator(t *testing.T) {
 	}()
 
 	errs := make(chan error)
-	ctx, _, _ := session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
+	ctx := session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
 
 	m.Start(ctx)
 
@@ -71,8 +71,12 @@ func TestStressCorrelator(t *testing.T) {
 		TimeoutRecvMutex sync.Mutex
 	)
 
-	errs := make(chan error)
-	genctx, recvctx, corctx := session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
+	var (
+		errs    = make(chan error)
+		genctx  = session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
+		recvctx = session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
+		corctx  = session.NewContexts(&session.Config{DebugHTTPMessages: true}, &session.FlowConfig{}, errs)
+	)
 
 	c := NewCorrelator(httptimeout)
 	c.Start(corctx)

--- a/httpx/har_test.go
+++ b/httpx/har_test.go
@@ -268,7 +268,7 @@ func TestHAR(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx, _, _ := session.NewContexts(&session.Config{},
+			ctx := session.NewContexts(&session.Config{},
 				&session.FlowConfig{
 					HTTPTimeout: 30 * time.Second,
 				}, nil)

--- a/httpx/input_format_test.go
+++ b/httpx/input_format_test.go
@@ -136,7 +136,7 @@ func TestInputFormatInit(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			errs := make(chan error, 10)
-			ctx, _, _ := session.NewContexts(&session.Config{Debug: true}, &session.FlowConfig{}, errs)
+			ctx := session.NewContexts(&session.Config{Debug: true}, &session.FlowConfig{}, errs)
 			ctx.SessionID = c.sessionID
 			inputFormat, err := NewInputFormat(ctx)
 			assert.NilError(t, err)

--- a/httpx/metrics_test.go
+++ b/httpx/metrics_test.go
@@ -132,7 +132,7 @@ func TestMetrics(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{
+			ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{
 				HTTPTimeout: 50 * time.Millisecond, // Short correlator time so we can actually get some timeouts.
 			}, nil)
 
@@ -155,7 +155,6 @@ func TestMetrics(t *testing.T) {
 
 			assert.DeepEqual(t, c.durations, backend.durations)
 			assert.DeepEqual(t, c.counters, backend.counters)
-
 		})
 	}
 }
@@ -180,7 +179,14 @@ func TestStressMetrics(t *testing.T) {
 		errs           = make(chan error)
 	)
 
-	genctx, metricsctx, _ := session.NewContexts(&session.Config{
+	genctx := session.NewContexts(&session.Config{
+		Debug:             false,
+		DebugHTTPMessages: false,
+	}, &session.FlowConfig{
+		HTTPTimeout: 50 * time.Millisecond, // Short correlator time so we can actually get some timeouts.
+	}, errs)
+
+	metricsctx := session.NewContexts(&session.Config{
 		Debug:             false,
 		DebugHTTPMessages: false,
 	}, &session.FlowConfig{
@@ -196,7 +202,6 @@ func TestStressMetrics(t *testing.T) {
 	go metrics.Init(metricsctx, nil)
 
 	for i := 0; i < numSenders; i++ {
-
 		go func() {
 			for msgCount := 0; msgCount < numMessagesPerSender; msgCount++ {
 				connID := ksuid.New().String()
@@ -228,7 +233,6 @@ func TestStressMetrics(t *testing.T) {
 				messageCountCh <- struct{}{}
 			}
 		}()
-
 	}
 
 	for {

--- a/internal/observe/read_closer.go
+++ b/internal/observe/read_closer.go
@@ -1,0 +1,42 @@
+package observe
+
+import (
+	"errors"
+	"io"
+)
+
+// ReadCloser is an observable io.ReadCloser.
+type ReadCloser interface {
+	io.ReadCloser
+	EOF() <-chan struct{}
+}
+
+func NewReadCloser(r io.ReadCloser) ReadCloser {
+	return &readCloser{
+		rc: r,
+		// Buffer this so that listening for EOF
+		// is not a requirement.
+		eof: make(chan struct{}, 1),
+	}
+}
+
+type readCloser struct {
+	rc  io.ReadCloser
+	eof chan struct{}
+}
+
+func (r *readCloser) Read(p []byte) (int, error) {
+	n, err := r.rc.Read(p)
+	if errors.Is(err, io.EOF) {
+		r.eof <- struct{}{}
+	}
+	return n, err
+}
+
+func (r *readCloser) EOF() <-chan struct{} {
+	return r.eof
+}
+
+func (r *readCloser) Close() error {
+	return r.rc.Close()
+}

--- a/internal/observe/read_closer_test.go
+++ b/internal/observe/read_closer_test.go
@@ -1,0 +1,37 @@
+package observe
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestReadCloser(t *testing.T) {
+	cases := []struct {
+		desc        string
+		rc          io.ReadCloser
+		errContains string
+	}{
+		{
+			desc: "EOF",
+			rc:   ioutil.NopCloser(strings.NewReader("a\nb\nc\n")),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			r := NewReadCloser(c.rc)
+
+			_, err := ioutil.ReadAll(r)
+
+			if c.errContains != "" {
+				assert.ErrorContains(t, err, c.errContains)
+			}
+
+			assert.Equal(t, 1, len(r.EOF()))
+			assert.NilError(t, r.Close())
+		})
+	}
+}

--- a/jsonx/jsonx.go
+++ b/jsonx/jsonx.go
@@ -44,8 +44,12 @@ func (i *inputFormat) Init(ctx session.Context, m middleware.Middleware, streams
 			}()
 
 			dec := json.NewDecoder(r)
-			go func() {
-				for {
+			for {
+				select {
+				case <-ctx.StdContext.Done():
+					ctx.Logger.Debug().Msg("context canceled")
+					return
+				default:
 					n, err := ctx.Registry.DecodeJSON(dec)
 					if errors.Is(err, io.EOF) {
 						return
@@ -62,9 +66,7 @@ func (i *inputFormat) Init(ctx session.Context, m middleware.Middleware, streams
 
 					i.out <- n
 				}
-			}()
-
-			<-ctx.StdContext.Done()
+			}
 		}(rdr)
 	}
 }

--- a/jsonx/jsonx_test.go
+++ b/jsonx/jsonx_test.go
@@ -47,9 +47,9 @@ func TestOutputFormat(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			var (
-				errs      = make(chan error, 1)
-				ctx, _, _ = session.NewContexts(nil, nil, errs)
-				f, _      = NewOutputFormat(ctx)
+				errs = make(chan error, 1)
+				ctx  = session.NewContexts(nil, nil, errs)
+				f, _ = NewOutputFormat(ctx)
 			)
 
 			go f.Init(ctx, c.buf)
@@ -108,8 +108,8 @@ func TestInputFormatInit(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			var (
-				errs      = make(chan error, 1)
-				ctx, _, _ = session.NewContexts(&session.Config{
+				errs = make(chan error, 1)
+				ctx  = session.NewContexts(&session.Config{
 					Debug: true,
 				}, &session.FlowConfig{}, errs)
 			)
@@ -128,6 +128,8 @@ func TestInputFormatInit(t *testing.T) {
 			for i := 0; i < len(c.out); i++ {
 				assert.DeepEqual(t, c.out[i], <-inputFormat.Out())
 			}
+
+			time.Sleep(50 * time.Millisecond)
 
 			ctx.Cancel()
 

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -70,7 +70,7 @@ func TestExec(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			ctx, _, _ := session.NewContexts(nil, nil, nil)
+			ctx := session.NewContexts(nil, nil, nil)
 			for i := 0; i < c.num; i++ {
 				req, err := c.m.Exec(ctx, c.header, c.l)
 				if c.errContains != "" {
@@ -122,7 +122,7 @@ func TestMiddleware(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			err := func() error {
-				ctx, _, _ := session.NewContexts(nil, nil, nil)
+				ctx := session.NewContexts(nil, nil, nil)
 				m, err := New(ctx, c.command)
 				assert.NilError(t, err)
 

--- a/s3compat/s3compat_test.go
+++ b/s3compat/s3compat_test.go
@@ -97,7 +97,7 @@ func TestSourceWithSink(t *testing.T) {
 			assert.NilError(t, err)
 
 			err = func() error {
-				ctx, _, _ := session.NewContexts(&session.Config{}, &session.FlowConfig{
+				ctx := session.NewContexts(&session.Config{}, &session.FlowConfig{
 					S3CompatEndpoint:   endpoint,
 					S3CompatAccessKey:  accessKey,
 					S3CompatSecretKey:  secretKey,

--- a/session/config.go
+++ b/session/config.go
@@ -17,9 +17,8 @@ type Config struct {
 
 // FlowConfig is a Flow config.
 type FlowConfig struct {
-	FlowDuration       time.Duration
-	InputDrainDuration time.Duration
-	ShutdownDuration   time.Duration
+	SourceDuration time.Duration
+	DrainDuration  time.Duration
 
 	Addr            string
 	CaptureResponse bool

--- a/session/config.go
+++ b/session/config.go
@@ -17,8 +17,8 @@ type Config struct {
 
 // FlowConfig is a Flow config.
 type FlowConfig struct {
-	SourceDuration time.Duration
-	DrainDuration  time.Duration
+	SourceDuration     time.Duration
+	InputDrainDuration time.Duration
 
 	Addr            string
 	CaptureResponse bool

--- a/session/context.go
+++ b/session/context.go
@@ -16,21 +16,17 @@ const (
 )
 
 // NewContexts creates a new set of contexts.
-func NewContexts(cfg *Config, flowCfg *FlowConfig, errs chan error) (Context, Context, Context) {
+func NewContexts(cfg *Config, flowCfg *FlowConfig, errs chan error) Context {
 	return NewContextsForWriter(cfg, flowCfg, errs, os.Stderr)
 }
 
 // NewContextsForWriter creates a new set of contexts
 // with logs written to a specific writer.
-func NewContextsForWriter(cfg *Config, flowCfg *FlowConfig, errs chan error, w io.Writer) (Context, Context, Context) {
+func NewContextsForWriter(cfg *Config, flowCfg *FlowConfig, errs chan error, w io.Writer) Context {
 	var (
-		sessionID = ksuid.New().String()
-
-		stdCtx1, cancel1 = context.WithCancel(context.Background())
-		stdCtx2, cancel2 = context.WithCancel(context.Background())
-		stdCtx3, cancel3 = context.WithCancel(context.Background())
-
-		registry = envelope.NewRegistry()
+		sessionID      = ksuid.New().String()
+		registry       = envelope.NewRegistry()
+		stdCtx, cancel = context.WithCancel(context.Background())
 	)
 
 	var (
@@ -48,35 +44,15 @@ func NewContextsForWriter(cfg *Config, flowCfg *FlowConfig, errs chan error, w i
 	}
 
 	return Context{
-			Config:     cfg,
-			FlowConfig: flowCfg,
-			SessionID:  sessionID,
-			StdContext: stdCtx1,
-			Cancel:     cancel1,
-			Errors:     errs,
-			Logger:     logger,
-			Registry:   registry,
-		},
-		Context{
-			Config:     cfg,
-			FlowConfig: flowCfg,
-			SessionID:  sessionID,
-			StdContext: stdCtx2,
-			Cancel:     cancel2,
-			Errors:     errs,
-			Logger:     logger,
-			Registry:   registry,
-		},
-		Context{
-			Config:     cfg,
-			FlowConfig: flowCfg,
-			SessionID:  sessionID,
-			StdContext: stdCtx3,
-			Cancel:     cancel3,
-			Errors:     errs,
-			Logger:     logger,
-			Registry:   registry,
-		}
+		Config:     cfg,
+		FlowConfig: flowCfg,
+		SessionID:  sessionID,
+		StdContext: stdCtx,
+		Cancel:     cancel,
+		Errors:     errs,
+		Logger:     logger,
+		Registry:   registry,
+	}
 }
 
 // Context is a context for a session.

--- a/session/context_test.go
+++ b/session/context_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestContexts(t *testing.T) {
 	var (
-		canceled         = make(chan struct{}, 3)
-		errs             = make(chan error, 3)
-		ctx1, ctx2, ctx3 = NewContexts(&Config{}, &FlowConfig{}, errs)
+		canceled = make(chan struct{}, 3)
+		errs     = make(chan error, 3)
+		ctx1     = NewContexts(&Config{}, &FlowConfig{}, errs)
 	)
 
 	fn := func(ctx Context) {
@@ -29,15 +29,11 @@ func TestContexts(t *testing.T) {
 	}
 
 	go fn(ctx1)
-	go fn(ctx2)
-	go fn(ctx3)
 
 	ctx1.Cancel()
-	ctx2.Cancel()
-	ctx3.Cancel()
 
 	time.Sleep(500 * time.Millisecond)
 
-	assert.Equal(t, 3, len(canceled))
-	assert.Equal(t, 3, len(errs))
+	assert.Equal(t, 1, len(canceled))
+	assert.Equal(t, 1, len(errs))
 }

--- a/tcp/source.go
+++ b/tcp/source.go
@@ -61,6 +61,7 @@ func (s *tcpSource) read(ctx session.Context, newCapture newCaptureFn, newListen
 		pool      = tcpassembly.NewStreamPool(factory)
 		assembler = tcpassembly.NewAssembler(pool)
 		ticker    = time.Tick(ctx.FlowConfig.TCPTimeout)
+		complete  = time.After(ctx.FlowConfig.SourceDuration)
 		packets   = listener.Packets()
 	)
 
@@ -95,6 +96,10 @@ func (s *tcpSource) read(ctx session.Context, newCapture newCaptureFn, newListen
 			assembler.FlushOlderThan(time.Now().Add(-ctx.FlowConfig.TCPTimeout))
 
 			factory.prune()
+
+		case <-complete:
+			factory.Close()
+			return
 
 		case <-ctx.StdContext.Done():
 			return

--- a/tcp/source_test.go
+++ b/tcp/source_test.go
@@ -87,7 +87,8 @@ func TestRead(t *testing.T) {
 		DebugPackets: true,
 	}
 	flowCfg := &session.FlowConfig{
-		TCPTimeout: 50 * time.Millisecond,
+		SourceDuration: 800 * time.Millisecond,
+		TCPTimeout:     50 * time.Millisecond,
 	}
 	cases := []struct {
 		desc     string
@@ -98,29 +99,29 @@ func TestRead(t *testing.T) {
 		out      []string
 	}{
 		{
-			desc: "nil",
-			cfg:  cfg,
+			desc:    "nil",
+			cfg:     cfg,
 			flowCfg: flowCfg,
-			data: []string{nilPayload},
+			data:    []string{nilPayload},
 		},
 		{
-			desc: "empty packet",
-			cfg:  cfg,
+			desc:    "empty packet",
+			cfg:     cfg,
 			flowCfg: flowCfg,
-			data: []string{""},
+			data:    []string{""},
 		},
 
 		{
-			desc: "wrong packet type",
-			cfg:  cfg,
+			desc:    "wrong packet type",
+			cfg:     cfg,
 			flowCfg: flowCfg,
-			data: []string{wrongPayloadType},
+			data:    []string{wrongPayloadType},
 		},
 		{
-			desc: "one packet",
-			cfg:  cfg,
+			desc:    "one packet",
+			cfg:     cfg,
 			flowCfg: flowCfg,
-			data: []string{"aaa"},
+			data:    []string{"aaa"},
 			out: []string{
 				"aaa",
 			},
@@ -129,8 +130,8 @@ func TestRead(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			var (
-				errs      = make(chan error)
-				ctx, _, _ = session.NewContexts(c.cfg, c.flowCfg, errs)
+				errs = make(chan error)
+				ctx  = session.NewContexts(c.cfg, c.flowCfg, errs)
 			)
 
 			defer ctx.Cancel()


### PR DESCRIPTION
This PR does a few things:

* Changes the behavior of flows by allowing _sources_ to determine whether a duration is needed (that's why `--flow-duration` is now `--source-duration`).
* Get rid of `inputCtx` and `outputCtx` and use a single context for everything.
* Get rid of `--shutdown-duration` and have a single `--drain-duration` flag to control how log `vhs` continues to wait before shutting down the flow.

## New Behavior

Before this change, `vhs` would run for the allotted `--flow-duration` and then shut down the flow. This was ideal for capturing network traffic (since the different contexts would handle cancellation in a way that allowed data to continue to flow through until everything was saved) but it's not ideal for anything else.

The main problem is seen when you try to take network traffic in GCS (as an example, this would apply to any source) and run it back through `vhs`. What should the `--flow-duration` be set for on this run? The user has to estimate a length of time longer than the amount of time that it takes `vhs` to process the data, and even then users are only doing this to game the system since the `--flow-duration` doesn't have any meaning in this context so they are only supplying a value to keep `vhs` from shutting down in the middle of processing their data.

My solution is to change the semantics of how `vhs` thinks about sources and flows. I realized that the "duration" is really a property of a source, not the flow itself. So replace `--flow-duration` with `--source-duration`. This flag is now available for all sources that need it (e.g. `tcp.Source` needs it but `gcs.Source` does not).

So how does a flow decide when to shut down? When the input source closes its `Source.Streams()` channel. This close is propogated down through the input types until the `flow.Input` itself realizes that there are no more streams to process, and then it signals to the parent flow (via a new `done` channel) that there is no more data.

#### Implementation details about how source streams are tracked

There are two things that a `flow.Input` needs to keep track of:
1. Does `source.Streams()` have any more _streams_ of data to send me? An example of a source stream is a TCP connection, a GCS file, etc.
2. Has the last stream that was seen been read to `EOF`? This is accomplished by wrapping the reader in an `observe.ReadCloser` (new internal package and type) which checks for EOF and signals when `EOF` is reached. This allows the input to know that all input data has actually been read. Once the last stream is `EOF` we can safely say that all input has been processed.

@ztreinhart The `observe` package is a good place to start exploring the other types we talked about that allow us to know whats going on inside streams and channels.

## Contexts

This allowed me to remove 2 of the 3 contexts we've been using because now we only need one since we aren't using contexts to signal shutdown. We are using the natural close semantics of the channels to do this. I feel like this is a lot simpler and easier to work with.

This is definitely a draft and I'm hoping that we can use this as a jumping off point for further discussion.