### PR TITLE
fix: Add extflags=static for build

### DIFF
--- a/docker/vhs/Dockerfile
+++ b/docker/vhs/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 
 RUN GODEBUG=netdns=go \
     go build \
-    -ldflags "-s" \
+    -ldflags "-s -extldflags=-static" \
     ./cmd/vhs
 
 ########################################################


### PR DESCRIPTION
Readd static build flags so we can properly include pcap.
This was accidentally removed during cleanup before.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>