### PR TITLE
Fix testing infrastructure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,35 +7,12 @@ on:
 
 jobs:
   test:
-    env:
-      IMAGE: "ghcr.io/${{ github.repository }}"
     name: test
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout
+
+    - name: checkout
       uses: actions/checkout@v2
-    -
-      name: Cache Docker layers
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    -
-      name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-    -
-      name: Docker Buildx (build)
-      run: |
-        docker buildx build \
-          --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --cache-to "type=local,dest=/tmp/.buildx-cache" \
-          --target test \
-          --platform linux/amd64 \
-          --output "type=image,push=false" \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --file ./docker/vhs/Dockerfile ./
+
+    - name: test
+      run: make test

--- a/.testignore
+++ b/.testignore
@@ -1,0 +1,2 @@
+github.com/rename-this/vhs/cmd/vhs
+github.com/rename-this/vhs/internal/smoke

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 .PHONY: test
 test:
-	go test -cover -race -coverprofile coverage.out `go list ./... | grep -v /cmd/vhs`
-
-.PHONY: test-all
-test-all: test
-	go test -cover -coverprofile coverage_cmd_vhs.out ./cmd/vhs
+	docker build \
+		--target base \
+		--tag vhs:test \
+		--file docker/vhs/Dockerfile \
+		. && \
+	docker run \
+		--rm \
+		--volume /var/run/docker.sock:/var/run/docker.sock \
+		--network host \
+		-it vhs:test \
+		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
 
 .PHONY: dev
 dev:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 		--rm \
 		--volume /var/run/docker.sock:/var/run/docker.sock \
 		--network host \
-		-it vhs:test \
+		-i vhs:test \
 		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
 
 .PHONY: dev

--- a/cmd/vhs/main_test.go
+++ b/cmd/vhs/main_test.go
@@ -1,5 +1,10 @@
 package main
 
+/*
+* These tests are too brittle and don't give us an accurate
+* picture of running the executable.
+*
+
 import (
 	"bufio"
 	"bytes"
@@ -222,3 +227,5 @@ func TestRoot(t *testing.T) {
 		})
 	}
 }
+
+*/

--- a/docker/vhs/Dockerfile
+++ b/docker/vhs/Dockerfile
@@ -1,21 +1,25 @@
-FROM golang:1.15 as builder
+FROM golang:1.15.6-alpine3.12 as base
+
+RUN apk add --no-cache --virtual .build-deps \
+	bash \
+	ca-certificates \
+	g++ \
+	jq \
+	libpcap-dev
 
 RUN go install -v -a std
-
-RUN apt update && \
-    apt install -y \
-    ca-certificates \
-    g++ \
-    jq \
-    libpcap-dev
 
 WORKDIR /src
 
 COPY go.* /src/
 
-RUN go mod download
+RUN go mod download -x
 
 COPY . .
+
+########################################################
+
+FROM base as builder
 
 RUN GODEBUG=netdns=go \
     go build \
@@ -30,10 +34,4 @@ COPY --from=builder /src/vhs /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/vhs"]
-
-########################################################
-
-FROM builder as test
-
-RUN make test
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rename-this/vhs
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go/storage v1.11.0

--- a/internal/smoke/smoke.go
+++ b/internal/smoke/smoke.go
@@ -36,6 +36,12 @@ func SetupDockertestPool(cfg Config) (*dockertest.Resource, func()) {
 		log.Fatalf("failed to run with options: %v", err)
 	}
 
+	cleanup := func() {
+		if err := pool.Purge(resource); err != nil {
+			log.Fatalf("failed to purge: %v", err)
+		}
+	}
+
 	if cfg.ReadinessPath != "" {
 		u := url.URL{
 			Scheme: "http",
@@ -54,13 +60,10 @@ func SetupDockertestPool(cfg Config) (*dockertest.Resource, func()) {
 			return nil
 		})
 		if err != nil {
+			cleanup()
 			log.Fatalf("failed readiness check: %v", err)
 		}
 	}
 
-	return resource, func() {
-		if err := pool.Purge(resource); err != nil {
-			log.Fatalf("failed to purge: %v", err)
-		}
-	}
+	return resource, cleanup
 }

--- a/s3compat/s3compat_test.go
+++ b/s3compat/s3compat_test.go
@@ -1,5 +1,3 @@
-// +build smoketest
-
 package s3compat
 
 import (
@@ -30,11 +28,10 @@ func TestMain(m *testing.M) {
 		ReadinessPath: "/minio/health/live",
 		ReadinessPort: "9000",
 		RunOptions: &dockertest.RunOptions{
-			Repository:   "minio/minio",
-			Tag:          "latest",
-			Cmd:          []string{"server", "/data"},
-			Env:          []string{"MINIO_ACCESS_KEY=" + accessKey, "MINIO_SECRET_KEY=" + secretKey},
-			ExposedPorts: []string{"9000"},
+			Repository: "minio/minio",
+			Tag:        "latest",
+			Cmd:        []string{"server", "/data"},
+			Env:        []string{"MINIO_ACCESS_KEY=" + accessKey, "MINIO_SECRET_KEY=" + secretKey},
 		},
 	})
 


### PR DESCRIPTION
This PR fixes our local and CI test setup by adopting a single approach:

* `make test` now runs all tests in a docker container, so docker is now a requirement for testing vhs.
* There is a `.testignore` package that can be used to list packages that should not (or cannot) be tested and are ignored by `make test`.
* The tests in `cmd/vhs` are completely disabled for now, see the code comment for rationale.
* The Dockerfile is structured slightly differently to allow us to use the base dependencies and source for testing without having the testing be a build step.
* Reverted back to an Alpine-based image to give us `musl` and a `musl` built libpcap.
* A few tweaks to `smoke` to make sure we don't leave containers laying around in the event of an error.