### PR TITLE
Fixed license file attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2021 VHS Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This correctly replaces the boilerplate in the LICENSE file with years and "VHS Authors"

Signed-off-by: Noah Abrahams <Noah.R.Abrahams@gmail.com>