### PR TITLE
HTTP output format

### DIFF
--- a/cmd/vhs/main.go
+++ b/cmd/vhs/main.go
@@ -238,6 +238,7 @@ func defaultParser() *flow.Parser {
 		OutputFormats: map[string]flow.OutputFormatCtor{
 			"har":  httpx.NewHAR,
 			"json": jsonx.NewOutputFormat,
+			"http": httpx.NewOutputFormat,
 		},
 
 		Sinks: map[string]flow.SinkCtor{

--- a/httpx/output_format.go
+++ b/httpx/output_format.go
@@ -1,0 +1,70 @@
+package httpx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/rename-this/vhs/flow"
+	"github.com/rename-this/vhs/session"
+)
+
+// NewOutputFormat creates an HTTP output format.
+func NewOutputFormat(_ session.Context) (flow.OutputFormat, error) {
+	return &outputFormat{
+		in: make(chan interface{}),
+	}, nil
+}
+
+type outputFormat struct {
+	in chan interface{}
+}
+
+func (o *outputFormat) In() chan<- interface{} {
+	return o.in
+}
+
+func (o *outputFormat) Init(ctx session.Context, w io.Writer) {
+	ctx.Logger = ctx.Logger.With().
+		Str(session.LoggerKeyComponent, "output_http").
+		Logger()
+
+	ctx.Logger.Debug().Msg("init")
+
+	var (
+		once   sync.Once
+		offset time.Duration
+	)
+
+	for {
+		select {
+		case n := <-o.in:
+			switch r := n.(type) {
+			case *Request:
+				once.Do(func() {
+					offset = time.Now().Sub(r.Created)
+				})
+
+				wait := r.Created.Add(offset).Sub(time.Now())
+				go o.writeRequest(ctx, wait, w, r)
+			case *Response:
+				// Ignore for now.
+			default:
+				ctx.Errors <- errors.New("http output format: unknown type")
+			}
+		case <-ctx.StdContext.Done():
+			ctx.Logger.Debug().Msg("context canceled")
+			return
+		}
+	}
+}
+
+func (o *outputFormat) writeRequest(ctx session.Context, wait time.Duration, w io.Writer, r *Request) {
+	time.Sleep(wait)
+
+	if err := r.StdRequest().Write(w); err != nil {
+		ctx.Errors <- fmt.Errorf("failed to write HTTP request: %w", err)
+	}
+}

--- a/httpx/output_format_test.go
+++ b/httpx/output_format_test.go
@@ -1,0 +1,111 @@
+package httpx
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/rename-this/vhs/internal/safebuffer"
+	"github.com/rename-this/vhs/session"
+	"github.com/segmentio/ksuid"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+type badmsg struct{}
+
+func (b *badmsg) GetConnectionID() string {
+	panic("not implemented") // TODO: Implement
+}
+
+func (b *badmsg) GetExchangeID() string {
+	panic("not implemented") // TODO: Implement
+}
+
+func (b *badmsg) SetCreated(_ time.Time) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (b *badmsg) SetSessionID(_ string) {
+	panic("not implemented") // TODO: Implement
+}
+
+func TestNewOutputFormat(t *testing.T) {
+	var (
+		start = time.Now().Add(-time.Hour)
+		u, _  = url.Parse("http://example.com")
+		n     = ksuid.New().String()
+		cl    = int64(len(n) + 3)
+	)
+	cases := []struct {
+		desc        string
+		messages    []Message
+		errContains string
+	}{
+		{
+			desc: "only requests",
+			messages: []Message{
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_0\n", Created: start.Add(100 * time.Millisecond)},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_1\n", Created: start.Add(100 * time.Millisecond)},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_2\n", Created: start.Add(100 * time.Millisecond)},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_3\n", Created: start.Add(100 * time.Millisecond)},
+			},
+		},
+		{
+			desc: "requests and responses",
+			messages: []Message{
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_0\n", Created: start.Add(100 * time.Millisecond)},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_1\n", Created: start.Add(100 * time.Millisecond)},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_2\n", Created: start.Add(100 * time.Millisecond)},
+				&Response{},
+				&Request{Method: "POST", URL: u, ContentLength: cl, Body: n + "_4\n", Created: start.Add(100 * time.Millisecond)},
+				&Response{},
+				&Response{},
+			},
+		},
+		{
+			desc: "wrong message type",
+			messages: []Message{
+				&badmsg{},
+			},
+			errContains: "unknown type",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			var (
+				errs = make(chan error, 1)
+				ctx  = session.NewContexts(nil, nil, errs)
+				o, _ = NewOutputFormat(ctx)
+				in   = o.In()
+				w    safebuffer.SafeBuffer
+			)
+
+			go o.Init(ctx, &w)
+
+			for _, m := range c.messages {
+				in <- m
+			}
+
+			time.Sleep(time.Second)
+
+			ctx.Cancel()
+
+			if c.errContains != "" {
+				assert.ErrorContains(t, <-errs, c.errContains)
+				return
+			}
+
+			allReqs := string(w.Bytes())
+
+			for i, r := range c.messages {
+				if _, ok := r.(*Request); !ok {
+					continue
+				}
+				nn := fmt.Sprintf("%s_%d", n, i)
+				assert.Assert(t, cmp.Contains(allReqs, nn))
+			}
+		})
+	}
+}

--- a/httpx/request.go
+++ b/httpx/request.go
@@ -8,6 +8,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/rename-this/vhs/envelope"
@@ -61,6 +62,25 @@ func (r *Request) SetCreated(created time.Time) { r.Created = created }
 
 // SetSessionID sets the session ID
 func (r *Request) SetSessionID(id string) { r.SessionID = id }
+
+// StdRequest converts a Request into an *http.Request.
+func (r *Request) StdRequest() *http.Request {
+	return &http.Request{
+		Method:           r.Method,
+		URL:              r.URL,
+		Proto:            r.Proto,
+		ProtoMajor:       r.ProtoMajor,
+		ProtoMinor:       r.ProtoMinor,
+		Header:           r.Header,
+		PostForm:         r.PostForm,
+		Body:             ioutil.NopCloser(strings.NewReader(r.Body)),
+		ContentLength:    r.ContentLength,
+		TransferEncoding: r.TransferEncoding,
+		Host:             r.Host,
+		Trailer:          r.Trailer,
+		RequestURI:       r.RequestURI,
+	}
+}
 
 // NewRequest creates a new Request.
 func NewRequest(b *bufio.Reader, connectionID string, exchangeID string, m *flow.Meta) (*Request, error) {


### PR DESCRIPTION
This adds a simple HTTP output format which allows `vhs` (when combined with `tcp.Sink`) to replay saved HTTP traffic.

Known limitations:
* This writes all traffic to a single TCP connection irrespective of what connection the original traffic used. There is work to be done to identify the unique connections and mimic the original traffic connection patterns.
* Responses are not captured, should they be? If so, where should they be stored?
* This has a rather crude scheduler for timing the requests to match the original traffic flow. This can be improved and hopefully in a way that can be verified with tests.

The reason I put known limitations is because I think this is a great place to get community feedback on the design of HTTP replay moving forward and I'd love to have future design of this area be a collaborative process.

Signed-off-by: Andrew Hare <andrew@stormforge.io>