### PR TITLE
Small HTTP bug fixes

### DIFF
--- a/httpx/output_format.go
+++ b/httpx/output_format.go
@@ -12,7 +12,8 @@ import (
 )
 
 // NewOutputFormat creates an HTTP output format.
-func NewOutputFormat(_ session.Context) (flow.OutputFormat, error) {
+func NewOutputFormat(ctx session.Context) (flow.OutputFormat, error) {
+	registerEnvelopes(ctx)
 	return &outputFormat{
 		in: make(chan interface{}),
 	}, nil

--- a/httpx/request.go
+++ b/httpx/request.go
@@ -74,7 +74,6 @@ func (r *Request) StdRequest() *http.Request {
 		Header:           r.Header,
 		PostForm:         r.PostForm,
 		Body:             ioutil.NopCloser(strings.NewReader(r.Body)),
-		ContentLength:    r.ContentLength,
 		TransferEncoding: r.TransferEncoding,
 		Host:             r.Host,
 		Trailer:          r.Trailer,


### PR DESCRIPTION
Two small fixes:

* Allow the standard library to set the `ContentLength` on requests.
* Make sure that the HTTP output format registers envelope types.

Signed-off-by: Andrew Hare <andrew@stormforge.io>