### PR TITLE
fix: Use different make target for github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
     -
       name: Set up environment
       run: |
-        make docs-ci
+        make init
     -
       name: Publish Site
       uses: chabad360/hugo-gh-pages@master


### PR DESCRIPTION
I think this should fix the merge to main CI build 

Signed-off-by: Brad Beam <brad.beam@stormforge.io>