### PR TITLE
refactor: Rework ci build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 coverage.out
+dist
+.git
+Dockerfile
+vhs/docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,72 +6,50 @@ on:
     - main
 
 jobs:
-  build:
-    env:
-      IMAGE: "ghcr.io/${{ github.repository }}"
-      PLATFORMS: "linux/arm64,linux/amd64,linux/arm/v7"
-    name: build
+
+  container:
+    name: container
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout
+    - name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: ${{ env.PLATFORMS }}
-    -
-      name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-    -
-      name: Cache Docker layers
-      uses: actions/cache@v2.1.4
+
+    - name: Cache Docker layers
       id: cache
+      uses: actions/cache@v2.1.4
       with:
-        path: /tmp/.buildx-cache
+        path: |
+          /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-    -
-      name: Build
-      run: |
-        docker buildx build \
-          --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --cache-to "type=local,dest=/tmp/.buildx-cache" \
-          --platform ${PLATFORMS} \
-          --target application \
-          --output "type=image,push=false" \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --file ./docker/vhs/Dockerfile ./
-    -
-      name: Login to ghcr.io
+
+    - name: Login to ghcr.io
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
         username: vcr-bot
         password: ${{ secrets.GHCR_TOKEN }}
-    -
-      name: Push
-      run: |
-        # push image:sha
-        docker buildx build \
-          --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --platform ${PLATFORMS} \
-          --target application \
-          --output "type=image,push=true" \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --file ./docker/vhs/Dockerfile ./
 
-        # push image:edge ( moving tag )
-        docker buildx build \
-          --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --platform ${PLATFORMS} \
-          --target application \
-          --output "type=image,push=true" \
-          --tag ${IMAGE}:edge \
-          --file ./docker/vhs/Dockerfile ./
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./docker/vhs/Dockerfile
+        platforms: linux/amd64
+        builder: ${{ steps.buildx.outputs.name }}
+        push: true
+        target: application
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          ghcr.io/${{ github.repository }}:edge
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
   docs:
     name: docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,8 +13,13 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+
     - name: Cache Go
-      id: cache
+      id: go-cache
       uses: actions/cache@v2.1.4
       with:
         path: |
@@ -25,7 +30,9 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: test
-      run: make test
+      run: |
+        sudo apt install -y bash libpcap-dev jq
+        make test-host
 
   container:
     name: container

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,56 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-
     - name: checkout
       uses: actions/checkout@v2
 
+    - name: Cache Go
+      id: cache
+      uses: actions/cache@v2.1.4
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys:
+          ${{ runner.os }}-go-
+
     - name: test
       run: make test
+
+  container:
+    name: container
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Cache Docker layers
+      id: cache
+      uses: actions/cache@v2.1.4
+      with:
+        path: |
+          /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./docker/vhs/Dockerfile
+        platforms: linux/amd64
+        builder: ${{ steps.buildx.outputs.name }}
+        push: false
+        target: application
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          ghcr.io/${{ github.repository }}:edge
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ test:
 		-i vhs:test \
 		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
 
+.PHONY: test-host
+test-host:
+		go test -cover -race -coverprofile coverage.out `go list ./... | grep -v -f .testignore`
+
 .PHONY: dev
 dev:
 	docker build -t vhs:dev . && \

--- a/docker/vhs/Dockerfile
+++ b/docker/vhs/Dockerfile
@@ -1,13 +1,9 @@
-FROM golang:1.15.6-alpine3.12 as base
-
-RUN apk add --no-cache --virtual .build-deps \
-	bash \
-	ca-certificates \
-	g++ \
-	jq \
-	libpcap-dev
+FROM golang:1.15 as base
 
 RUN go install -v -a std
+
+RUN apt update && \
+    apt install -y  libpcap-dev
 
 WORKDIR /src
 
@@ -17,21 +13,17 @@ RUN go mod download -x
 
 COPY . .
 
-########################################################
-
-FROM base as builder
-
-RUN GODEBUG=netdns=go \
-    go build \
-    -ldflags "-s -extldflags=-static" \
-    ./cmd/vhs
+RUN go build ./cmd/vhs
 
 ########################################################
 
-FROM scratch as application
+FROM gcr.io/distroless/base-debian10 as application
 
-COPY --from=builder /src/vhs /
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /src/vhs /
+
+# Copy libpcap
+COPY --from=base /usr/include/pcap /usr/include/pcap
+COPY --from=base /usr/lib/x86_64-linux-gnu/libpcap* /usr/lib/x86_64-linux-gnu/
 
 ENTRYPOINT ["/vhs"]
 

--- a/docker/vhs/Dockerfile
+++ b/docker/vhs/Dockerfile
@@ -3,7 +3,10 @@ FROM golang:1.15 as base
 RUN go install -v -a std
 
 RUN apt update && \
-    apt install -y  libpcap-dev
+    apt install -y  \
+    bash \
+    libpcap-dev \
+    jq
 
 WORKDIR /src
 


### PR DESCRIPTION
- feat: Migrate to distroless base image
In preparation for plugins, we should have a few other components in our runtime environment.

- chore: Update github workflows
This switches around some of the manual effort we were doing
with docker buildx and instead uses the recommended
`docker/build-push-action` action.


Signed-off-by: Brad Beam <brad.beam@stormforge.io>
