### PR TITLE
Add completed channel to allow buffered formats to flush

### DIFF
--- a/cmd/vhs/main.go
+++ b/cmd/vhs/main.go
@@ -187,9 +187,7 @@ func root(cfg *core.Config, flowCfg *core.FlowConfig, inputLine string, outputLi
 		ctx.Cancel()
 	}()
 
-	go f.Run(ctx, m)
-
-	<-ctx.StdContext.Done()
+	f.Run(ctx, m)
 
 	if cfg.ProfilePathMemory != "" {
 		f, err := os.Create(cfg.ProfilePathMemory)

--- a/core/output_format.go
+++ b/core/output_format.go
@@ -6,4 +6,5 @@ import "io"
 type OutputFormat interface {
 	Init(Context, io.Writer)
 	In() chan<- interface{}
+	Complete() <-chan struct{}
 }

--- a/file/file.go
+++ b/file/file.go
@@ -19,6 +19,8 @@ type source struct {
 }
 
 func (s *source) Init(ctx core.Context) {
+	defer close(s.streams)
+
 	ctx.Logger = ctx.Logger.With().
 		Str(core.LoggerKeyComponent, "file_source").
 		Logger()
@@ -33,8 +35,6 @@ func (s *source) Init(ctx core.Context) {
 		file: file,
 		meta: core.NewMeta(ctx.FlowConfig.InputFile, nil),
 	}
-
-	<-ctx.StdContext.Done()
 }
 
 func (s *source) Streams() <-chan core.InputReader {

--- a/flow/output_test.go
+++ b/flow/output_test.go
@@ -78,9 +78,7 @@ func TestOutput(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			// hack: Make this big enough to handle any errors we
-			// might end up with.
-			errs := make(chan error, 10)
+			errs := make(chan error, 1)
 			ctx := core.NewContext(nil, nil, errs)
 
 			for _, o := range c.oo {
@@ -96,8 +94,9 @@ func TestOutput(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 
 			ctx.Cancel()
-
-			time.Sleep(500 * time.Millisecond)
+			for _, o := range c.oo {
+				<-o.Done()
+			}
 
 			if c.errContains == "" {
 				s := c.oo[0].Sink.(*coretest.TestSink)

--- a/jsonx/jsonx.go
+++ b/jsonx/jsonx.go
@@ -72,15 +72,23 @@ func (i *inputFormat) Init(ctx core.Context, m core.Middleware, streams <-chan c
 // NewOutputFormat creates a JSON output.
 func NewOutputFormat(_ core.Context) (core.OutputFormat, error) {
 	return &outputFormat{
-		in: make(chan interface{}),
+		in:       make(chan interface{}),
+		complete: make(chan struct{}, 1),
 	}, nil
 }
 
 type outputFormat struct {
-	in chan interface{}
+	in       chan interface{}
+	complete chan struct{}
 }
 
-func (f *outputFormat) In() chan<- interface{} { return f.in }
+func (f *outputFormat) In() chan<- interface{} {
+	return f.in
+}
+
+func (f *outputFormat) Complete() <-chan struct{} {
+	return f.complete
+}
 
 func (f *outputFormat) Init(ctx core.Context, w io.Writer) {
 	ctx.Logger = ctx.Logger.With().

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -272,6 +272,7 @@ func newTestOutputFormat(core.Context) (core.OutputFormat, error) { return &test
 type testOutputFormat struct {}
 func (*testOutputFormat) Init(core.Context, io.Writer) {}
 func (*testOutputFormat) In() chan<- interface{} { return nil }
+func (*testOutputFormat) Complete() <-chan struct{} { return nil }
 
 func OutputFormats() map[string]core.OutputFormatCtor { 
 	return map[string]core.OutputFormatCtor{


### PR DESCRIPTION
Fixes #42 

This PR fixes buffered output formats (like HAR). In order for buffered formats to complete writing to the sink, they need to be able to signal to the output when they are complete.

Signed-off-by: Andrew Hare <andrew@stormforge.io>