### PR TITLE
feat: Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  build:
+    name: build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Cache Go
+      id: go-cache
+      uses: actions/cache@v2.1.4
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys:
+          ${{ runner.os }}-go-
+
+    - name: test
+      run: |
+        sudo apt install -y bash libpcap-dev jq
+        make test-host
+
+    - name: Login to ghcr.io
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: vcr-bot
+        password: ${{ secrets.GHCR_TOKEN }}
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
+


### PR DESCRIPTION
This PR adds a release action that is triggered when a release is published on GitHub. This action uses `goreleaser` to build linux binaries in the form of a tarball and a debian package, which are automatically attached to the release. I have tested this in my own fork and it seems to be working well. Comments and suggestions appreciated.

Signed-off-by: Zach Reinhart <zach@stormforge.io>